### PR TITLE
Support single db, multi-table order by SQL

### DIFF
--- a/pkg/runtime/plan/simple_select.go
+++ b/pkg/runtime/plan/simple_select.go
@@ -141,7 +141,38 @@ func (s *SimpleQueryPlan) generate(sb *strings.Builder, args *[]int) error {
 				return errors.WithStack(err)
 			}
 		}
+
+		if len(stmt.OrderBy) > 0 {
+			s.resetOrderBy(s.Stmt, sb, args)
+		}
 	}
 
+	return nil
+}
+
+func (s *SimpleQueryPlan) resetOrderBy(tgt *ast.SelectStatement, sb *strings.Builder, args *[]int) error {
+	var (
+		builder strings.Builder
+	)
+	builder.WriteString("SELECT * FROM (")
+	builder.WriteString(sb.String())
+	builder.WriteString(") ")
+	if len(tgt.From[0].Alias()) > 0 {
+		builder.WriteString(tgt.From[0].Alias())
+	} else {
+		builder.WriteString(" T ")
+	}
+	builder.WriteString(" ORDER BY ")
+	if err := tgt.OrderBy[0].Restore(ast.RestoreDefault, &builder, args); err != nil {
+		return errors.WithStack(err)
+	}
+	for i := 1; i < len(tgt.OrderBy); i++ {
+		builder.WriteString(", ")
+		if err := tgt.OrderBy[i].Restore(ast.RestoreDefault, &builder, args); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	sb.Reset()
+	sb.WriteString(builder.String())
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

For #92 .

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
Now, it is support those scenes:

```
select * from student order by uid asc, name desc;

select * from student t order by t.uid asc, name desc;

select uid as a from student t order by a asc;
```
