### PR TITLE
support insert select stmt for non-sharding table

### DIFF
--- a/pkg/runtime/ast/ast.go
+++ b/pkg/runtime/ast/ast.go
@@ -506,6 +506,23 @@ func (cc *convCtx) convInsertStmt(stmt *ast.InsertStmt) Statement {
 		}
 	}
 
+	if stmt.Select != nil {
+		switch v := stmt.Select.(type) {
+		case *ast.SelectStmt:
+			return &InsertSelectStatement{
+				baseInsertStatement: &bi,
+				sel:                 cc.convSelectStmt(v),
+				duplicatedUpdates:   updates,
+			}
+		case *ast.SetOprStmt:
+			return &InsertSelectStatement{
+				baseInsertStatement: &bi,
+				unionSel:            cc.convUnionStmt(v),
+				duplicatedUpdates:   updates,
+			}
+		}
+	}
+
 	return &InsertStatement{
 		baseInsertStatement: &bi,
 		values:              values,

--- a/pkg/runtime/ast/ast_test.go
+++ b/pkg/runtime/ast/ast_test.go
@@ -347,6 +347,35 @@ func TestParse_InsertStmt(t *testing.T) {
 		})
 	}
 
+	for _, it := range []tt{
+		{
+			"insert into student select * from student_tmp",
+			"INSERT INTO `student` SELECT * FROM `student_tmp`",
+		},
+		{
+			"insert into student(id,name) select emp_no, name from employees limit 10,2",
+			"INSERT INTO `student`(`id`, `name`) SELECT `emp_no`,`name` FROM `employees` LIMIT 10,2",
+		},
+		{
+			"insert into student(id,name) select emp_no, name from employees on duplicate key update version=version+1,modified_at=NOW()",
+			"INSERT INTO `student`(`id`, `name`) SELECT `emp_no`,`name` FROM `employees` ON DUPLICATE KEY UPDATE `version` = `version`+1, `modified_at` = NOW()",
+		},
+		{
+			"insert student select id, score from student_tmp union select id * 10, score * 10 from student_tmp",
+			"INSERT INTO `student` SELECT `id`,`score` FROM `student_tmp` UNION SELECT `id`*10,`score`*10 FROM `student_tmp`",
+		},
+	} {
+		t.Run(it.input, func(t *testing.T) {
+			stmt, err := Parse(it.input)
+			assert.NoError(t, err)
+			assert.IsTypef(t, (*InsertSelectStatement)(nil), stmt, "should be insert-select statement")
+
+			actual, err := RestoreToString(RestoreDefault, stmt.(Restorer))
+			assert.NoError(t, err, "should restore ok")
+			assert.Equal(t, it.expect, actual)
+		})
+	}
+
 }
 
 func TestRestoreCount(t *testing.T) {

--- a/pkg/runtime/optimize/optimizer.go
+++ b/pkg/runtime/optimize/optimizer.go
@@ -106,6 +106,8 @@ func (o optimizer) doOptimize(ctx context.Context, conn proto.VConn, stmt rast.S
 		return o.optimizeSelect(ctx, conn, t, args)
 	case *rast.InsertStatement:
 		return o.optimizeInsert(ctx, conn, t, args)
+	case *rast.InsertSelectStatement:
+		return o.optimizeInsertSelect(ctx, conn, t, args)
 	case *rast.DeleteStatement:
 		return o.optimizeDelete(ctx, t, args)
 	case *rast.UpdateStatement:
@@ -610,6 +612,24 @@ func (o optimizer) optimizeInsert(ctx context.Context, conn proto.VConn, stmt *r
 	}
 
 	return ret, nil
+}
+
+func (o optimizer) optimizeInsertSelect(ctx context.Context, conn proto.VConn, stmt *rast.InsertSelectStatement, args []interface{}) (proto.Plan, error) {
+	var (
+		ru  = rcontext.Rule(ctx)
+		ret = plan.NewInsertSelectPlan()
+	)
+
+	ret.BindArgs(args)
+
+	if _, ok := ru.VTable(stmt.Table().Suffix()); !ok { // insert into non-sharding table
+		ret.Batch[""] = stmt
+		return ret, nil
+	}
+
+	// TODO: handle shard keys.
+
+	return nil, errors.New("not support insert-select into sharding table")
 }
 
 func (o optimizer) optimizeDelete(ctx context.Context, stmt *rast.DeleteStatement, args []interface{}) (proto.Plan, error) {

--- a/pkg/runtime/plan/insert_select.go
+++ b/pkg/runtime/plan/insert_select.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package plan
+
+import (
+	"context"
+	"strings"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+import (
+	"github.com/arana-db/arana/pkg/proto"
+	"github.com/arana-db/arana/pkg/resultx"
+	"github.com/arana-db/arana/pkg/runtime/ast"
+)
+
+var _ proto.Plan = (*InsertSelectPlan)(nil)
+
+type InsertSelectPlan struct {
+	basePlan
+	Batch map[string]*ast.InsertSelectStatement
+}
+
+func NewInsertSelectPlan() *InsertSelectPlan {
+	return &InsertSelectPlan{
+		Batch: make(map[string]*ast.InsertSelectStatement),
+	}
+}
+
+func (sp *InsertSelectPlan) Type() proto.PlanType {
+	return proto.PlanTypeExec
+}
+
+func (sp *InsertSelectPlan) ExecIn(ctx context.Context, conn proto.VConn) (proto.Result, error) {
+	var (
+		affects      uint64
+		lastInsertId uint64
+	)
+	// TODO: consider wrap a transaction if insert into multiple databases
+	// TODO: insert in parallel
+	for db, insert := range sp.Batch {
+		id, affected, err := sp.doInsert(ctx, conn, db, insert)
+		if err != nil {
+			return nil, err
+		}
+		affects += affected
+		if id > lastInsertId {
+			lastInsertId = id
+		}
+	}
+
+	return resultx.New(resultx.WithLastInsertID(lastInsertId), resultx.WithRowsAffected(affects)), nil
+}
+
+func (sp *InsertSelectPlan) doInsert(ctx context.Context, conn proto.VConn, db string, stmt *ast.InsertSelectStatement) (uint64, uint64, error) {
+	var (
+		sb   strings.Builder
+		args []int
+	)
+
+	if err := stmt.Restore(ast.RestoreDefault, &sb, &args); err != nil {
+		return 0, 0, errors.Wrap(err, "cannot restore insert statement")
+	}
+	res, err := conn.Exec(ctx, db, sb.String(), sp.toArgs(args)...)
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+
+	defer resultx.Drain(res)
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+
+	return id, affected, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #187 

**Special notes for your reviewer**:
Only support insert-select statement for non-sharding table.

**Does this PR introduce a user-facing change?**:
1) INSERT INTO `student` SELECT * FROM `student_tmp`
2) INSERT INTO `student`(`id`, `name`) SELECT `emp_no`,`name` FROM `employees` LIMIT 10,2
3) INSERT INTO `student`(`id`, `name`) SELECT `emp_no`,`name` FROM `employees` ON DUPLICATE KEY UPDATE `version` = `version`+1, `modified_at` = NOW()
4) INSERT INTO `student` SELECT `id`,`score` FROM `student_tmp` UNION SELECT `id`*10,`score`*10 FROM `student_tmp`

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```