### PR TITLE
fix snowflake id offset

### DIFF
--- a/pkg/sequence/snowflake/snowflake.go
+++ b/pkg/sequence/snowflake/snowflake.go
@@ -92,7 +92,7 @@ var (
 	_defaultStepBits uint8 = 12
 
 	stepMask      int64 = -1 ^ (-1 << _defaultStepBits)
-	timeShift           = _defaultNodeBits + _defaultNodeBits
+	timeShift           = _defaultNodeBits + _defaultStepBits
 	workIdShift         = _defaultStepBits
 	startWallTime       = time.Now()
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
The format of the snowflake id is 
0 + timestamp(41 bit) + work id(10 bit) + sequence id(12 bit)
and the timestamp should be offset 22 bits to the left.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```