### PR TITLE
Feature: support shadow type match regex (#365)

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -87,15 +87,6 @@ data:
               password: "123456"
               database: employees_0003
               weight: r10w10
-        - name: employees_shadow
-          nodes:
-            - name: node_shadow
-              host: arana-mysql
-              port: 3306
-              username: root
-              password: "123456"
-              database: employees_shadow
-              weight: r10w10
   sharding_rule:
     tables:
       - name: employees.student
@@ -121,8 +112,7 @@ data:
   shadow_rule:
     tables:
       - name: employees.student
-        enable: false
-        group_node: employees_shadow
+        enable: true
         match_rules:
           - operation: [insert,update]
             match_type: value

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -123,7 +123,7 @@ data:
             match_type: regex
             attributes:
               - column: name
-                regex: "^hanmeimei$"
+                value: "^hanmeimei$"
           - operation: [select]
             match_type: hint
             attributes:

--- a/integration_test/config/shadow/config.yaml
+++ b/integration_test/config/shadow/config.yaml
@@ -87,15 +87,6 @@ data:
               password: "123456"
               database: employees_0003
               weight: r10w10
-        - name: employees_shadow
-          nodes:
-            - name: node_shadow
-              host: arana-mysql
-              port: 3306
-              username: root
-              password: "123456"
-              database: employees_shadow
-              weight: r10w10
   sharding_rule:
     tables:
       - name: employees.student
@@ -121,7 +112,6 @@ data:
     tables:
       - name: employees.student
         enable: true
-        group_node: employees_shadow
         match_rules:
           - operation: [select]
             match_type: hint

--- a/integration_test/scene/shadow/integration_test.go
+++ b/integration_test/scene/shadow/integration_test.go
@@ -58,28 +58,9 @@ func (s *IntegrationSuite) TestShadowScene() {
 	assert.NoError(t, err, "should begin a new tx")
 
 	cases := s.TestCases()
-	for _, sqlCase := range cases.ExecCases {
-		for _, sense := range sqlCase.Sense {
-			if strings.Compare(strings.TrimSpace(sense), "shadow") == 1 {
-				params := strings.Split(sqlCase.Parameters, ",")
-				args := make([]interface{}, 0, len(params))
-				for _, param := range params {
-					k, _ := test.GetValueByType(param)
-					args = append(args, k)
-				}
-
-				// Execute sql
-				result, err := tx.Exec(sqlCase.SQL, args...)
-				assert.NoError(t, err, "exec not right")
-				err = sqlCase.ExpectedResult.CompareRow(result)
-				assert.NoError(t, err, err)
-			}
-		}
-	}
-
 	for _, sqlCase := range cases.QueryRowCases {
 		for _, sense := range sqlCase.Sense {
-			if strings.Compare(strings.TrimSpace(sense), "shadow") == 1 {
+			if strings.Compare(strings.TrimSpace(sense), "shadow") == 0 {
 				params := strings.Split(sqlCase.Parameters, ",")
 				args := make([]interface{}, 0, len(params))
 				for _, param := range params {
@@ -87,8 +68,8 @@ func (s *IntegrationSuite) TestShadowScene() {
 					args = append(args, k)
 				}
 
-				result := tx.QueryRow(sqlCase.SQL, args...)
-				err = sqlCase.ExpectedResult.CompareRow(result)
+				result := tx.QueryRow(sqlCase.SQL)
+				err := sqlCase.ExpectedResult.CompareRow(result)
 				assert.NoError(t, err, err)
 			}
 		}

--- a/integration_test/testcase/casetest.yaml
+++ b/integration_test/testcase/casetest.yaml
@@ -42,6 +42,35 @@ query_row_cases:
     expected:
       type: "valueInt"
       value: "1"
+  - sql: "SELECT COUNT(1) FROM student WHERE uid=1"
+    parameters: "1:int"
+    sense:
+      - shadow
+    expected:
+      type: "valueInt"
+      value: "1"
+  - sql: "/*A! shadow(shadow) */ SELECT COUNT(1) FROM student WHERE uid=1"
+    parameters: "1:int"
+    sense:
+      - shadow
+    expected:
+      type: "valueInt"
+      value: "0"
+  - sql: "SELECT COUNT(1) FROM student WHERE name='lilei'"
+    parameters: "lilei:string"
+    sense:
+      - shadow
+    expected:
+      type: "valueInt"
+      value: "0"
+  - sql: "SELECT COUNT(1) FROM student WHERE name='hanmeimei'"
+    parameters: "hanmeimei:string"
+    sense:
+      - shadow
+    expected:
+      type: "valueInt"
+      value: "0"
+
 exec_cases:
   - sql: "INSERT INTO sequence(name,value,modified_at) VALUES(?,?,NOW())"
     parameters: "1:string, 2:string"
@@ -60,9 +89,9 @@ exec_cases:
       value: 1
   - sql: "/*A! shadow(shadow) */ update student set score=100.0 where uid = ?"
     parameters: "2:int"
-      sense:
+    sense:
         - shadow
-      expected:
+    expected:
         type: "rowAffect"
         value: 1
   - sql: "/*A! shadow(shadow) */ delete from student"

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -29,6 +29,12 @@ const (
 )
 
 const (
+	HeaderPrefix           = "Tables_in_"
+	AranaSystemTablePrefix = "__arana_"
+	ShadowTablePrefix      = "__shadow_"
+)
+
+const (
 	ShadowMatchRegex = "regex"
 	ShadowMatchValue = "value"
 	ShadowMatchHint  = "hint"

--- a/pkg/runtime/ast/expression_atom.go
+++ b/pkg/runtime/ast/expression_atom.go
@@ -132,7 +132,7 @@ func (u *UnaryExpressionAtom) Accept(visitor Visitor) (interface{}, error) {
 }
 
 func (u *UnaryExpressionAtom) IsOperatorNot() bool {
-	switch strings.ToUpper(strings.Trim(u.Operator, " ")) {
+	switch strings.ToUpper(strings.TrimSpace(u.Operator)) {
 	case "!", "NOT":
 		return true
 	}

--- a/pkg/runtime/ast/expression_atom.go
+++ b/pkg/runtime/ast/expression_atom.go
@@ -132,7 +132,7 @@ func (u *UnaryExpressionAtom) Accept(visitor Visitor) (interface{}, error) {
 }
 
 func (u *UnaryExpressionAtom) IsOperatorNot() bool {
-	switch u.Operator {
+	switch strings.ToUpper(strings.Trim(u.Operator, " ")) {
 	case "!", "NOT":
 		return true
 	}

--- a/pkg/runtime/optimize/dml/delete.go
+++ b/pkg/runtime/optimize/dml/delete.go
@@ -60,13 +60,15 @@ func optimizeDelete(ctx context.Context, o *optimize.Optimizer) (proto.Plan, err
 	if shards == nil {
 		transparent := plan.Transparent(stmt, o.Args)
 		if matchShadow {
-			transparent.SetDB(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
+			//TODO: fix it
+			//transparent.SetDB(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
 		}
 		return transparent, nil
 	}
 
 	if matchShadow {
-		shards.ReplaceDb(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
+		//TODO: fix it
+		//shards.ReplaceDb(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
 	}
 
 	ret := dml.NewSimpleDeletePlan(stmt)

--- a/pkg/runtime/optimize/dml/insert.go
+++ b/pkg/runtime/optimize/dml/insert.go
@@ -133,7 +133,8 @@ func optimizeInsert(ctx context.Context, o *optimize.Optimizer) (proto.Plan, err
 
 		for k, v := range shards {
 			if matchShadow {
-				k = o.ShadowRule.GetDatabase(tableName.Suffix())
+				//TODO: fix it
+				//k = o.ShadowRule.GetDatabase(tableName.Suffix())
 			}
 			db = k
 			table = v[0]
@@ -148,7 +149,8 @@ func optimizeInsert(ctx context.Context, o *optimize.Optimizer) (proto.Plan, err
 
 	for db, slot := range slots {
 		if matchShadow {
-			db = o.ShadowRule.GetDatabase(tableName.Suffix())
+			//TODO: fix it
+			//db = o.ShadowRule.GetDatabase(tableName.Suffix())
 		}
 		for table, indexes := range slot {
 			// clone insert stmt without values

--- a/pkg/runtime/optimize/dml/update.go
+++ b/pkg/runtime/optimize/dml/update.go
@@ -103,7 +103,8 @@ func optimizeUpdate(_ context.Context, o *optimize.Optimizer) (proto.Plan, error
 	}
 
 	if matchShadow {
-		shards.ReplaceDb(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
+		//TODO: fix it
+		//shards.ReplaceDb(o.ShadowRule.GetDatabase(stmt.Table.Suffix()))
 	}
 
 	ret := dml.NewUpdatePlan(stmt)

--- a/pkg/runtime/plan/dal/show_tables.go
+++ b/pkg/runtime/plan/dal/show_tables.go
@@ -28,6 +28,7 @@ import (
 )
 
 import (
+	constdb "github.com/arana-db/arana/pkg/constants"
 	constant "github.com/arana-db/arana/pkg/constants/mysql"
 	"github.com/arana-db/arana/pkg/dataset"
 	"github.com/arana-db/arana/pkg/mysql"
@@ -40,11 +41,6 @@ import (
 )
 
 var _ proto.Plan = (*ShowTablesPlan)(nil)
-
-const (
-	headerPrefix           = "Tables_in_"
-	aranaSystemTablePrefix = "__arana_"
-)
 
 type ShowTablesPlan struct {
 	plan.BasePlan
@@ -94,7 +90,7 @@ func (st *ShowTablesPlan) ExecIn(ctx context.Context, conn proto.VConn) (proto.R
 
 	fields, _ := ds.Fields()
 
-	fields[0] = mysql.NewField(headerPrefix+rcontext.Schema(ctx), constant.FieldTypeVarString)
+	fields[0] = mysql.NewField(constdb.HeaderPrefix+rcontext.Schema(ctx), constant.FieldTypeVarString)
 
 	// filter duplicates
 	duplicates := make(map[string]struct{})
@@ -132,7 +128,10 @@ func (st *ShowTablesPlan) ExecIn(ctx context.Context, conn proto.VConn) (proto.R
 			}
 
 			tableName := vr.Values()[0].(string)
-			if strings.HasPrefix(tableName, aranaSystemTablePrefix) {
+			if strings.HasPrefix(tableName, constdb.AranaSystemTablePrefix) {
+				return false
+			}
+			if strings.HasPrefix(tableName, constdb.ShadowTablePrefix) {
 				return false
 			}
 			if _, ok := duplicates[tableName]; ok {

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -40,7 +40,6 @@
 --
 
 CREATE DATABASE IF NOT EXISTS employees_0000 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-CREATE DATABASE IF NOT EXISTS employees_shadow CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 USE employees_0000;
 

--- a/scripts/sharding.sql
+++ b/scripts/sharding.sql
@@ -22,6 +22,7 @@ CREATE DATABASE IF NOT EXISTS employees_0003 CHARACTER SET utf8mb4 COLLATE utf8m
 
 CREATE DATABASE IF NOT EXISTS employees_0000_r CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
+-- employees_0000, student_0000~student_0007
 CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0000`
 (
     `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -37,631 +38,102 @@ CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0000`
     UNIQUE KEY `uk_uid` (`uid`),
     KEY `nickname` (`nickname`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0001` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0002` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0003` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0004` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0005` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0006` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0007` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0001`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0001, student_0008~student_0015
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0008` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0009` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0010` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0011` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0012` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0013` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0014` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0015` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0002`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0002, student_0016~student_0023
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0016` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0017` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0018` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0019` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0020` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0021` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0022` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0023` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0003`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0003, student_0024~student_0031
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0024` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0025` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0026` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0027` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0028` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0029` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0030` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0031` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0004`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0000_r, student_0000~student_0007
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0000` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0001` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0002` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0003` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0004` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0005` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0006` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0007` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0005`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0000, __shadow_student_0000~__shadow_student_0007
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0000` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0001` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0002` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0003` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0004` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0005` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0006` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000`.`__shadow_student_0007` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0006`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0001, __shadow_student_0008~__shadow_student_0015
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0008` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0009` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0010` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0011` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0012` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0013` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0014` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0001`.`__shadow_student_0015` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0000`.`student_0007`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0002, __shadow_student_0016~__shadow_student_0023
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0016` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0017` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0018` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0019` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0020` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0021` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0022` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0002`.`__shadow_student_0023` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0008`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- employees_0003, __shadow_student_0024~__shadow_student_0031
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0024` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0025` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0026` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0027` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0028` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0029` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0030` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0003`.`__shadow_student_0031` LIKE `employees_0000`.`student_0000`;
 
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0009`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0010`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0011`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0012`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0013`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0014`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0001`.`student_0015`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0016`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0017`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0018`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0019`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0020`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0021`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0022`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0002`.`student_0023`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0024`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0025`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0026`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0027`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0028`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0029`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0030`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0003`.`student_0031`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0000`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0001`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0002`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0003`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0004`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0005`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0006`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS `employees_0000_r`.`student_0007`
-(
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-    `uid` BIGINT(20) UNSIGNED NOT NULL,
-    `name` VARCHAR(255) NOT NULL,
-    `score` DECIMAL(6,2) DEFAULT '0',
-    `nickname` VARCHAR(255) DEFAULT NULL,
-    `gender` TINYINT(4) NULL,
-    `birth_year` SMALLINT(5) UNSIGNED DEFAULT '0',
-    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `modified_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_uid` (`uid`),
-    KEY `nickname` (`nickname`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
+-- employees_0000_r, __shadow_student_0000~__shadow_student_0007
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0000` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0001` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0002` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0003` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0004` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0005` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0006` LIKE `employees_0000`.`student_0000`;
+CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0007` LIKE `employees_0000`.`student_0000`;
 
 INSERT INTO employees_0000.student_0001(id,uid,name,score,nickname,gender,birth_year,created_at,modified_at) VALUES (1, 1, 'arana', 95, 'Awesome Arana', 0, 2021, NOW(), NOW());

--- a/scripts/sharding.sql
+++ b/scripts/sharding.sql
@@ -137,3 +137,4 @@ CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0006` LIKE `empl
 CREATE TABLE IF NOT EXISTS `employees_0000_r`.`__shadow_student_0007` LIKE `employees_0000`.`student_0000`;
 
 INSERT INTO employees_0000.student_0001(id,uid,name,score,nickname,gender,birth_year,created_at,modified_at) VALUES (1, 1, 'arana', 95, 'Awesome Arana', 0, 2021, NOW(), NOW());
+INSERT INTO employees_0000.__shadow_student_0002(id,uid,name,score,nickname,gender,birth_year,created_at,modified_at) VALUES (2, 2, 'hanmeimei', 97, 'Shadow Arana', 0, 2021, NOW(), NOW());

--- a/test/dataset.go
+++ b/test/dataset.go
@@ -93,7 +93,7 @@ type (
 	}
 
 	Expected struct {
-		ResultType string `yaml:"resultType"`
+		ResultType string `yaml:"type"`
 		Value      string `yaml:"value"`
 	}
 )


### PR DESCRIPTION
1. create shadow tables in init.sql & sharding.sql
2. hide shadow tables for "show tables" command
3. impl shadow match hint rule (only select)
4. support shadow type match regex (only select)

Test Cases:
SELECT name FROM student WHERE uid = 1; //sharding
SELECT name FROM student WHERE name = 'lilei'; //fullscan
SELECT name FROM student WHERE uid = 1 and name = 'lilei'; //sharding
SELECT name FROM student WHERE uid = 1 or name = 'lilei'; //fullscan

/*A! shadow(shadow) */ SELECT name FROM student WHERE uid = 1; //sharding shadow tables
/*A! shadow(shadow) */ SELECT name FROM student WHERE name = 'lilei'; //fullscan shadow tables
/*A! shadow(shadow) */ SELECT name FROM student WHERE uid = 1 and name = 'lilei'; //sharding shadow tables
/*A! shadow(shadow) */ SELECT name FROM student WHERE uid = 1 or name = 'lilei'; //fullscan shadow tables

regex：only support eq & ne
SELECT name FROM student WHERE name = 'hanmeimei'; //fullscan shadow tables
SELECT name FROM student WHERE uid = 1 and name = 'hanmeimei'; //sharding shadow tables
SELECT name FROM student WHERE uid = 1 or name = 'hanmeimei'; //fullscan shadow tables
SELECT name FROM student WHERE NOT name = 'hanmeimei'; //fullscan


<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```