### PR TITLE
fix: when args of CONCAT have any NULL, it should return NULL

### DIFF
--- a/pkg/runtime/function2/concat_test.go
+++ b/pkg/runtime/function2/concat_test.go
@@ -29,6 +29,7 @@ import (
 
 import (
 	"github.com/arana-db/arana/pkg/proto"
+	"github.com/arana-db/arana/pkg/runtime/ast"
 )
 
 func TestConcat(t *testing.T) {
@@ -43,6 +44,7 @@ func TestConcat(t *testing.T) {
 		{[]proto.Value{"hello ", "world"}, "hello world"},
 		{[]proto.Value{1, 2, 3}, "123"},
 		{[]proto.Value{"hello ", 42}, "hello 42"},
+		{[]proto.Value{"hello", 1, ast.Null{}}, "NULL"},
 	} {
 		t.Run(fmt.Sprint(next.out), func(t *testing.T) {
 			var inputs []proto.Valuer


### PR DESCRIPTION
Signed-off-by: charlie <charlie1213800@gmail.com>

<!--  Thanks for sending a pull request!
-->

**What this PR does**:

According to the doc of MYSQL, when args of CONCAT have any NULL, it should also return NULL

before
```
mysql> select concat(1, 2, NULL, max(id)) from student;

+-----------------------------+
| concat(1, 2, NULL, max(id)) |
+-----------------------------+
| 12NULL1                     |
+-----------------------------+
1 row in set (0.03 sec)
```

now
```
mysql> select concat(1, 2, NULL, max(id)) from student;

+-----------------------------+
| concat(1, 2, NULL, max(id)) |
+-----------------------------+
| NULL                        |
+-----------------------------+
1 row in set (0.03 sec)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
