### PR TITLE
bump: upgrade actions version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
     name: auto generate changelog
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       - run: go version
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/go-integration.yml
+++ b/.github/workflows/go-integration.yml
@@ -40,8 +40,8 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
       - run: go version

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       - run: go version
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,8 +40,8 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
       - run: go version

--- a/.github/workflows/licence-checker.yml
+++ b/.github/workflows/licence-checker.yml
@@ -31,7 +31,7 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Check License Header
         uses: apache/skywalking-eyes@main

--- a/.github/workflows/linelint.yml
+++ b/.github/workflows/linelint.yml
@@ -26,6 +26,6 @@ jobs:
     name: Check if all files end in newline
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Linelint
         uses: fernandrone/linelint@0.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             goos: windows
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1.20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: reviewdog/action-golangci-lint@v2
         with:
@@ -48,9 +48,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.20"
 

--- a/pkg/runtime/ast/ast_test.go
+++ b/pkg/runtime/ast/ast_test.go
@@ -400,7 +400,6 @@ func TestQuote(t *testing.T) {
 	sel := stmt.(*SelectStatement)
 	var sb strings.Builder
 	_ = sel.Restore(RestoreDefault, &sb, nil)
-	t.Log(sb.String())
 	assert.Equal(t, "SELECT `a``bc`", sb.String())
 }
 


### PR DESCRIPTION
![img_v3_02f3_547f711a-1a0c-48d7-aa2f-127260956f1h](https://github.com/user-attachments/assets/a0c89acd-e4e3-456a-816d-142e7e72ef36)

https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded the `actions/checkout` action to version `v4` across multiple GitHub Actions workflows, enhancing repository checkout processes.
	- Updated the `actions/setup-go` action to version `v5` in relevant workflows, improving Go environment setup.

- **Chores**
	- Routine updates to action versions for improved performance and functionality across various workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->